### PR TITLE
check for existence of ABIEncoderV2 prior to matching to resolve TypeError

### DIFF
--- a/flatten.js
+++ b/flatten.js
@@ -15,7 +15,7 @@ async function flatten(config) {
   let experimentals = flatSourceCode.match(experimentalReg);
 
   let pragmaVersion = versions.slice(-1)[0] ? versions.slice(-1)[0] : "";
-  let pragmaExperimental = experimentals[0] ? experimentals[0] : "";
+  let pragmaExperimental = experimentals && experimentals[0] ? experimentals[0] : "";
 
   flatSourceCode = flatSourceCode.replace(versionReg, "")
   flatSourceCode = flatSourceCode.replace(experimentalReg, "")


### PR DESCRIPTION
Bug observed:

If you have a combined contract that does not have at least one contract with "pragma experimental ABIEncoderV2;", running truffle run flatten errors with 

```
TypeError: Cannot read property '0' of null
    at flatten (~node_modules/truffle-flatten/flatten.js:18:41)
Truffle v5.0.39 (core: 5.0.39)
Node v10.16.3
error Command failed with exit code 1.
``` 

Adding a simple check for null prior to proceeding allows for non experimental ABIEncodeV2 contracts to be flattened using this truffle plugin.