### PR TITLE
Remove caret version when determining pragma version of flattened contract

### DIFF
--- a/flatten.js
+++ b/flatten.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const fs = require('fs-extra')
 
 async function flatten(config) {
@@ -12,6 +13,7 @@ async function flatten(config) {
   let flatSourceCode = await flattener([ artifactSource ], '.');
 
   let versions = flatSourceCode.match(versionReg).sort();
+  _.remove(versions, function(e) { return e.includes('^'); });
   let experimentals = flatSourceCode.match(experimentalReg);
 
   let pragmaVersion = versions.slice(-1)[0] ? versions.slice(-1)[0] : "";

--- a/flatten.js
+++ b/flatten.js
@@ -15,7 +15,7 @@ async function flatten(config) {
   let experimentals = flatSourceCode.match(experimentalReg);
 
   let pragmaVersion = versions.slice(-1)[0] ? versions.slice(-1)[0] : "";
-  let pragmaExperimental = experimentals[0] ? experimentals[0] : "";
+  let pragmaExperimental = experimentals && experimentals[0] ? experimentals[0] : "";
 
   flatSourceCode = flatSourceCode.replace(versionReg, "")
   flatSourceCode = flatSourceCode.replace(experimentalReg, "")

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^8.1.0",
+    "lodash": "4.17.15",
     "truffle-flattener": "^1.4.2"
   },
   "bugs": {


### PR DESCRIPTION
If two version, one containing a nonfixed version is found, expected behavior is to choose 0.5.12 at the top of the file.
`[ 'pragma solidity 0.5.12;', 'pragma solidity ^0.5.0;' ]`

Expected that the flatten file should choose
`pragma solidity 0.5.12;`

Current Behavior: 
`pragma solidity ^0.5.0;`  is put at the top of the flattened file

